### PR TITLE
fix: 댓글 수정 및 삭제 권한 오류 수정

### DIFF
--- a/src/main/java/miniProject/board/controller/ArticleController.java
+++ b/src/main/java/miniProject/board/controller/ArticleController.java
@@ -80,6 +80,12 @@ public class ArticleController {
         // 댓글 리스트 추가
         Pageable pageable = PageRequest.of(commentPage - 1, 10);
         Page<CommentDto.Response> comments = commentService.findCommentsByArticleId(articleId, pageable);
+
+        comments.forEach(comment -> {
+            comment.setAuthorId(comment.getAuthorId().equals(memberSessionDto.getId()) ?
+                    memberSessionDto.getId() : null);
+        });
+
         model.addAttribute("comments", comments.getContent());
         model.addAttribute("commentPage", commentPage);
         model.addAttribute("commentTotalPages", comments.getTotalPages());

--- a/src/main/java/miniProject/board/dto/CommentDto.java
+++ b/src/main/java/miniProject/board/dto/CommentDto.java
@@ -31,6 +31,7 @@ public class CommentDto {
         private String username;
         private String createdAt;
         private String updatedAt;
+        private Long authorId;
 
         public Response(Comment comment) {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
@@ -39,6 +40,7 @@ public class CommentDto {
             this.username = comment.getMember().getUsername();
             this.createdAt = comment.getCreatedAt().format(formatter);
             this.updatedAt = comment.getUpdatedAt().format(formatter);
+            this.authorId = comment.getMember().getId();
         }
     }
 }

--- a/src/main/resources/templates/articles/articleView.html
+++ b/src/main/resources/templates/articles/articleView.html
@@ -84,7 +84,7 @@
                         <p><strong th:text="${comment.username}">작성자</strong> - <span th:text="${comment.createdAt}">작성일</span></p>
                         <p th:text="${comment.content}" class="mt-2">내용</p>
                     </div>
-                    <div class="flex space-x-4 mt-2" th:if="${isAuthor}">
+                    <div class="flex space-x-4 mt-2" th:if="${comment.authorId != null}">
                         <button type="button" th:onclick="'toggleEditForm(' + ${comment.id} + ')'" class="py-2 px-4 bg-green-600 text-white rounded hover:bg-green-700">수정</button>
                         <form th:action="@{'/comments/' + ${comment.id} + '?deleteFrom=articles'}" method="post" th:onsubmit="return confirm('정말로 삭제하시겠습니까?')">
                             <input type="hidden" name="_method" value="delete">


### PR DESCRIPTION
-> 각 댓글에 대한 삭제 권한은 댓글 작성자 본인에게만 주어짐
-> 타인에게는 수정 및 삭제 버튼이 보이지 않음. 이는 게시글과 동일.

### 체크 리스트
<!-- 아래 항목들을 체크해 주세요. -->
- [x] PR 제목을 커밋 메시지 형식으로 작성 (예: feat: 기능 구현)
- [x] PR 요청 시 Assignee 본인 선택
- [x] PR 요청 시 Reviewers 팀원 선택

### 개요
<!-- 작업의 내용을 간략하게 작성해 주세요. -->
댓글 수정 및 삭제에 관한 권한 오류 수정
- 댓글 작성자 본인을 제외한 사용자에게는 수정 및 삭제 버튼이 보이지 않도록 수정


### 작업 내용 (Optional)
<!-- 작업 내용에 대한 설명을 자세히 작성해 주세요. -->