### PR TITLE
fix: 아이디 찾기 및 비밀번호 변경 로직 관련 오류 수정

### DIFF
--- a/src/main/java/miniProject/board/controller/member/FindAccountsController.java
+++ b/src/main/java/miniProject/board/controller/member/FindAccountsController.java
@@ -3,13 +3,15 @@ package miniProject.board.controller.member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import miniProject.board.dto.EmailDto;
-import miniProject.board.dto.MemberDto;
 import miniProject.board.service.member.FindAccountsService;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.List;
@@ -44,43 +46,60 @@ public class FindAccountsController {
 
         // 인증 폼에 필요한 데이터를 리다이렉트 속성에 추가
         redirectAttributes.addFlashAttribute("email", emailRequest.getEmail());
+        redirectAttributes.addFlashAttribute("sentCode", code);
 
         return "redirect:/findAccounts/emailAuth";
     }
 
     // 3. 이메일 인증 번호 입력 폼으로 이동
     @GetMapping("/emailAuth")
-    public String emailAuthForm(@ModelAttribute("email") String email, Model model) {
+    public String emailAuthForm(@ModelAttribute("email") String email,
+                                @ModelAttribute("sentCode") String sentCode,
+                                Model model) {
         log.debug("Entry: email Auth Form to Find Accounts Controller");
 
-        model.addAttribute("emailCheckDto", new EmailDto.RequestForUsername());
+        model.addAttribute("emailCheckDto", new EmailDto.CheckForUsername());
         model.addAttribute("email", email);
+        model.addAttribute("code", sentCode);
 
         return "email/AuthFormForAccounts";
     }
 
     // 4. 이메일 인증 번호 입력 확인
     @PostMapping("/emailAuth")
-    public String checkKey(@ModelAttribute("email") String email,
-                           @Validated @ModelAttribute("emailCheckDto") EmailDto.CheckForUsername emailCheck,
-                           BindingResult bindingResult, RedirectAttributes redirectAttributes) {
+    public String checkKey(@Validated @ModelAttribute("emailCheckDto") EmailDto.CheckForUsername emailCheck,
+                           BindingResult bindingResult, RedirectAttributes redirectAttributes, Model model) {
         log.debug("Entry: Check Auth Key Controller");
 
         if (bindingResult.hasErrors()) {
-            redirectAttributes.addFlashAttribute("email", email);
+            redirectAttributes.addFlashAttribute("email", emailCheck.getEmail());
+            redirectAttributes.addFlashAttribute("sentCode", emailCheck.getSentCode());
             return "redirect:/findAccounts/emailAuth";
         }
 
-        boolean check = findAccountsService.checkAuthNum(email, emailCheck.getAuthCode());
+        String result = findAccountsService.checkAuthNum(
+                emailCheck.getEmail(),
+                emailCheck.getSentCode(),
+                emailCheck.getAuthCode()
+        );
+        log.debug("결과 : " + result);
 
-        if (!check) {
+        if (result.equals("expired")) {
+            // 인증 코드 만료 처리
+            log.debug("인증 코드 만료됨");
+            redirectAttributes.addFlashAttribute("error", "인증 코드가 만료되었습니다. 이메일을 다시 입력해 주세요.");
+            return "redirect:/findAccounts/emailCheck";
+        } else if(result.equals("mismatch")) {
+            // 인증 코드 불일치 처리
             log.debug("인증 번호 오류");
-            redirectAttributes.addFlashAttribute("email", email);
-            return "redirect:/findAccounts/emailAuth";
+            model.addAttribute("error", "잘못된 인증 코드입니다. 다시 시도해 주세요.");
+            model.addAttribute("email", emailCheck.getEmail());
+            model.addAttribute("sentCode", emailCheck.getSentCode());
+            return "email/AuthFormForAccounts";
         }
 
-        log.debug("회원 인증 성공!");
-        redirectAttributes.addFlashAttribute("email", email);
+        log.debug(result + " - 회원 인증 성공!");
+        redirectAttributes.addFlashAttribute("email", emailCheck.getEmail());
         return "redirect:/findAccounts/showAccounts";
     }
 

--- a/src/main/java/miniProject/board/controller/member/FindAccountsController.java
+++ b/src/main/java/miniProject/board/controller/member/FindAccountsController.java
@@ -2,6 +2,7 @@ package miniProject.board.controller.member;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import miniProject.board.dto.EmailDto;
 import miniProject.board.dto.MemberDto;
 import miniProject.board.service.member.FindAccountsService;
 import org.springframework.stereotype.Controller;
@@ -24,13 +25,13 @@ public class FindAccountsController {
     // 1. 이메일 인증 폼으로 이동
     @GetMapping("/emailCheck")
     public String emailForm(Model model) {
-        model.addAttribute("emailRequestDto", new MemberDto.EmailRequest.forUsername());
+        model.addAttribute("emailRequestDto", new EmailDto.RequestForUsername());
         return "email/emailFormForAccounts";
     }
 
     // 2. 이메일 전송
     @PostMapping("/emailCheck")
-    public String sendEmail(@Validated @ModelAttribute("emailRequestDto") MemberDto.EmailRequest.forUsername emailRequest,
+    public String sendEmail(@Validated @ModelAttribute("emailRequestDto") EmailDto.RequestForUsername emailRequest,
                             BindingResult bindingResult, RedirectAttributes redirectAttributes) {
         log.debug("Entry: Send Email Controller");
 
@@ -52,7 +53,7 @@ public class FindAccountsController {
     public String emailAuthForm(@ModelAttribute("email") String email, Model model) {
         log.debug("Entry: email Auth Form to Find Accounts Controller");
 
-        model.addAttribute("emailCheckDto", new MemberDto.EmailCheck.forUsername());
+        model.addAttribute("emailCheckDto", new EmailDto.RequestForUsername());
         model.addAttribute("email", email);
 
         return "email/AuthFormForAccounts";
@@ -61,7 +62,7 @@ public class FindAccountsController {
     // 4. 이메일 인증 번호 입력 확인
     @PostMapping("/emailAuth")
     public String checkKey(@ModelAttribute("email") String email,
-                           @Validated @ModelAttribute("emailCheckDto") MemberDto.EmailCheck.forUsername emailCheck,
+                           @Validated @ModelAttribute("emailCheckDto") EmailDto.CheckForUsername emailCheck,
                            BindingResult bindingResult, RedirectAttributes redirectAttributes) {
         log.debug("Entry: Check Auth Key Controller");
 

--- a/src/main/java/miniProject/board/controller/member/PwChangeController.java
+++ b/src/main/java/miniProject/board/controller/member/PwChangeController.java
@@ -30,7 +30,7 @@ public class PwChangeController {
     // 2. 이메일 등록 여부 확인
     @PostMapping("/emailCheck")
     public String sendEmail(@Validated @ModelAttribute("emailRequestDto") EmailDto.RequestForPW emailRequest,
-                            BindingResult bindingResult, RedirectAttributes redirectAttributes) {
+                            BindingResult bindingResult, RedirectAttributes redirectAttributes, Model model) {
         log.debug("Entry: Send Email Controller");
 
         if (bindingResult.hasErrors()) {
@@ -38,11 +38,20 @@ public class PwChangeController {
         }
 
         String code = pwChangeService.checkEmail(emailRequest.getUsername(), emailRequest.getEmail());
+        if(code == null) {
+            log.debug("ID가 없거나 등록되지 않은 이메일입니다.");
+            model.addAttribute("error", "ID가 없거나 등록되지 않은 이메일입니다. 다시 입력해주세요.");
+            model.addAttribute("email", emailRequest.getEmail());
+            model.addAttribute("username", emailRequest.getUsername());
+            return "email/emailFormForPw";
+        }
+
         log.debug("to: " + emailRequest.getEmail() + ", code: " + code);
 
         // 인증 폼에 필요한 데이터를 리다이렉트 속성에 추가
         redirectAttributes.addFlashAttribute("username", emailRequest.getUsername());
         redirectAttributes.addFlashAttribute("email", emailRequest.getEmail());
+        redirectAttributes.addFlashAttribute("sentCode", code);
 
         // 리다이렉트로 인증 폼으로 이동
         return "redirect:/changePW/emailAuth";
@@ -51,40 +60,56 @@ public class PwChangeController {
     // 3. 이메일 인증 번호 입력 폼으로 이동
     @GetMapping("/emailAuth")
     public String emailAuthForm(@ModelAttribute("username") String username,
-                                @ModelAttribute("email") String email, Model model) {
+                                @ModelAttribute("email") String email,
+                                @ModelAttribute("sentCode") String sentCode,
+                                Model model) {
         log.debug("Entry: email Auth Form to Change Password Controller");
 
         model.addAttribute("emailCheckDto", new EmailDto.CheckForPW());
         model.addAttribute("username", username);
         model.addAttribute("email", email);
+        model.addAttribute("code", sentCode);
 
         return "email/AuthFormForPw";
     }
 
     // 4. 이메일 인증 번호 입력 확인
     @PostMapping("/emailAuth")
-    public String checkKey(@ModelAttribute("email") String email, @ModelAttribute("username") String username,
-                           @Validated @ModelAttribute("emailCheckDto") EmailDto.CheckForPW emailCheck,
-                           BindingResult bindingResult, RedirectAttributes redirectAttributes) {
+    public String checkKey(@Validated @ModelAttribute("emailCheckDto") EmailDto.CheckForPW emailCheck,
+                           BindingResult bindingResult, RedirectAttributes redirectAttributes, Model model) {
         log.debug("Entry: Check Auth Key Controller");
 
         if (bindingResult.hasErrors()) {
-            redirectAttributes.addFlashAttribute("username", username);
-            redirectAttributes.addFlashAttribute("email", email);
+            redirectAttributes.addFlashAttribute("username", emailCheck.getUsername());
+            redirectAttributes.addFlashAttribute("email", emailCheck.getEmail());
+            redirectAttributes.addFlashAttribute("sentCode", emailCheck.getSentCode());
             return "redirect:/changePW/emailAuth";
         }
 
-        boolean check = pwChangeService.checkAuthNum(email, emailCheck.getAuthCode());
+        String result = pwChangeService.checkAuthNum(
+                emailCheck.getEmail(),
+                emailCheck.getSentCode(),
+                emailCheck.getAuthCode()
+        );
+        log.debug("결과 : " + result);
 
-        if (!check) {
+        if (result.equals("expired")) {
+            // 인증 코드 만료 처리
+            log.debug("인증 코드 만료됨");
+            redirectAttributes.addFlashAttribute("error", "인증 코드가 만료되었습니다. 이메일을 다시 입력해 주세요.");
+            return "redirect:/changePW/emailCheck";
+        } else if(result.equals("mismatch")) {
+            // 인증 코드 불일치 처리
             log.debug("인증 번호 오류");
-            redirectAttributes.addFlashAttribute("username", username);
-            redirectAttributes.addFlashAttribute("email", email);
-            return "redirect:/changePW/emailAuth";
+            model.addAttribute("error", "잘못된 인증 코드입니다. 다시 시도해 주세요.");
+            model.addAttribute("username", emailCheck.getUsername());
+            model.addAttribute("email", emailCheck.getEmail());
+            model.addAttribute("sentCode", emailCheck.getSentCode());
+            return "email/AuthFormForPw";
         }
 
         log.debug("회원 인증 성공!");
-        redirectAttributes.addFlashAttribute("username", username);
+        redirectAttributes.addFlashAttribute("username", emailCheck.getUsername());
         return "redirect:/changePW/newPassword";
     }
 
@@ -99,7 +124,7 @@ public class PwChangeController {
     // 6. 신규 비밀번호 저장
     @PatchMapping("/newPassword")
     public String changePW(@Validated @ModelAttribute("changePWDto") MemberDto.ChangePW changePWDto,
-                           BindingResult bindingResult, RedirectAttributes redirectAttributes) {
+                           BindingResult bindingResult, RedirectAttributes redirectAttributes, Model model) {
         log.debug("Entry: Change Password Controller");
 
         if (bindingResult.hasErrors()) {
@@ -107,11 +132,17 @@ public class PwChangeController {
             return "redirect:/changePW/newPassword";
         }
 
-        boolean check = pwChangeService.changePW(changePWDto.getUsername(), changePWDto.getPassword());
-        if (!check) {
-            log.debug("비밀번호 변경 중 오류 발생");
-            redirectAttributes.addFlashAttribute("username", changePWDto.getUsername());
-            return "redirect:/changePW/newPassword";
+        String result = pwChangeService.changePW(
+                changePWDto.getUsername(), changePWDto.getPassword(), changePWDto.getConfirmPassword()
+        );
+        if (result.equals("mismatch")) {
+            log.debug("비밀번호, 비밀번호 확인 불일치");
+            model.addAttribute("username", changePWDto.getUsername());
+            model.addAttribute("error", "비밀번호와 비밀번호 확인이 일치하지 않습니다. 다시 입력해주세요.");
+            return "member/changePwForm";
+        } else if(result.equals("unidentified")) {
+            log.debug("확인할 수 없는 사용자");
+            return "redirect:/changePW/emailCheck";
         }
 
         log.debug("비밀번호 변경 성공");

--- a/src/main/java/miniProject/board/controller/member/PwChangeController.java
+++ b/src/main/java/miniProject/board/controller/member/PwChangeController.java
@@ -2,6 +2,7 @@ package miniProject.board.controller.member;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import miniProject.board.dto.EmailDto;
 import miniProject.board.dto.MemberDto;
 import miniProject.board.service.member.PwChangeService;
 import org.springframework.stereotype.Controller;
@@ -22,13 +23,13 @@ public class PwChangeController {
     // 1. 이메일 인증 폼으로 이동
     @GetMapping("/emailCheck")
     public String emailForm(Model model) {
-        model.addAttribute("emailRequestDto", new MemberDto.EmailRequest.forPW());
+        model.addAttribute("emailRequestDto", new EmailDto.RequestForPW());
         return "email/emailFormForPw";
     }
 
     // 2. 이메일 등록 여부 확인
     @PostMapping("/emailCheck")
-    public String sendEmail(@Validated @ModelAttribute("emailRequestDto") MemberDto.EmailRequest.forPW emailRequest,
+    public String sendEmail(@Validated @ModelAttribute("emailRequestDto") EmailDto.RequestForPW emailRequest,
                             BindingResult bindingResult, RedirectAttributes redirectAttributes) {
         log.debug("Entry: Send Email Controller");
 
@@ -53,7 +54,7 @@ public class PwChangeController {
                                 @ModelAttribute("email") String email, Model model) {
         log.debug("Entry: email Auth Form to Change Password Controller");
 
-        model.addAttribute("emailCheckDto", new MemberDto.EmailCheck.forPW());
+        model.addAttribute("emailCheckDto", new EmailDto.CheckForPW());
         model.addAttribute("username", username);
         model.addAttribute("email", email);
 
@@ -63,7 +64,7 @@ public class PwChangeController {
     // 4. 이메일 인증 번호 입력 확인
     @PostMapping("/emailAuth")
     public String checkKey(@ModelAttribute("email") String email, @ModelAttribute("username") String username,
-                           @Validated @ModelAttribute("emailCheckDto") MemberDto.EmailCheck.forPW emailCheck,
+                           @Validated @ModelAttribute("emailCheckDto") EmailDto.CheckForPW emailCheck,
                            BindingResult bindingResult, RedirectAttributes redirectAttributes) {
         log.debug("Entry: Check Auth Key Controller");
 

--- a/src/main/java/miniProject/board/dto/EmailDto.java
+++ b/src/main/java/miniProject/board/dto/EmailDto.java
@@ -36,6 +36,9 @@ public class EmailDto {
         private String email;
 
         @NotEmpty
+        private String sentCode;
+
+        @NotEmpty
         private String authCode;
     }
 

--- a/src/main/java/miniProject/board/dto/EmailDto.java
+++ b/src/main/java/miniProject/board/dto/EmailDto.java
@@ -54,6 +54,9 @@ public class EmailDto {
         private String email;
 
         @NotEmpty
+        private String sentCode;
+
+        @NotEmpty
         private String authCode;
     }
 }

--- a/src/main/java/miniProject/board/dto/EmailDto.java
+++ b/src/main/java/miniProject/board/dto/EmailDto.java
@@ -1,0 +1,56 @@
+package miniProject.board.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.*;
+
+public class EmailDto {
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class RequestForUsername {
+        @NotEmpty
+        @Email
+        private String email;
+    }
+
+    @Getter @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class RequestForPW {
+        @NotEmpty
+        private String username;
+
+        @NotEmpty
+        @Email
+        private String email;
+    }
+
+    @Getter @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class CheckForUsername {
+        @NotEmpty
+        @Email
+        private String email;
+
+        @NotEmpty
+        private String authCode;
+    }
+
+    @Getter @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class CheckForPW {
+        @NotEmpty
+        private String username;
+
+        @NotEmpty
+        @Email
+        private String email;
+
+        @NotEmpty
+        private String authCode;
+    }
+}

--- a/src/main/java/miniProject/board/dto/MemberDto.java
+++ b/src/main/java/miniProject/board/dto/MemberDto.java
@@ -6,6 +6,9 @@ import jakarta.validation.constraints.Size;
 import lombok.*;
 import miniProject.board.entity.Member;
 
+import static miniProject.board.dto.constants.MemberConst.PASSWORD_MAX_SIZE;
+import static miniProject.board.dto.constants.MemberConst.PASSWORD_MIN_SIZE;
+
 public class MemberDto {
 
     @Getter @Setter
@@ -22,7 +25,7 @@ public class MemberDto {
         private String nickname;
 
         @NotEmpty
-        @Size(min = 8, max = 15)
+        @Size(min = PASSWORD_MIN_SIZE, max = PASSWORD_MAX_SIZE)
         private String password;
 
         private String description;
@@ -48,11 +51,11 @@ public class MemberDto {
         private String username;
 
         @NotEmpty
-        @Size(min = 8, max = 15)
+        @Size(min = PASSWORD_MIN_SIZE, max = PASSWORD_MAX_SIZE)
         private String password;
 
         @NotEmpty
-        @Size(min = 8, max = 15)
+        @Size(min = PASSWORD_MIN_SIZE, max = PASSWORD_MAX_SIZE)
         private String confirmPassword;
 
         @Email
@@ -67,62 +70,8 @@ public class MemberDto {
         private String username;
 
         @NotEmpty
-        @Size(min = 8, max = 15)
+        @Size(min = PASSWORD_MIN_SIZE, max = PASSWORD_MAX_SIZE)
         private String password;
-    }
-
-    public static class EmailRequest {
-
-        @Getter @Setter
-        @NoArgsConstructor
-        @AllArgsConstructor(access = AccessLevel.PRIVATE)
-        public static class forUsername {
-            @NotEmpty
-            @Email
-            private String email;
-        }
-
-        @Getter @Setter
-        @NoArgsConstructor
-        @AllArgsConstructor(access = AccessLevel.PRIVATE)
-        public static class forPW {
-            @NotEmpty
-            private String username;
-
-            @NotEmpty
-            @Email
-            private String email;
-        }
-    }
-
-    public static class EmailCheck {
-
-        @Getter @Setter
-        @NoArgsConstructor
-        @AllArgsConstructor(access = AccessLevel.PRIVATE)
-        public static class forUsername {
-            @NotEmpty
-            @Email
-            private String email;
-
-            @NotEmpty
-            private String authCode;
-        }
-
-        @Getter @Setter
-        @NoArgsConstructor
-        @AllArgsConstructor(access = AccessLevel.PRIVATE)
-        public static class forPW {
-            @NotEmpty
-            private String username;
-
-            @NotEmpty
-            @Email
-            private String email;
-
-            @NotEmpty
-            private String authCode;
-        }
     }
 
     @Getter @Setter
@@ -133,11 +82,11 @@ public class MemberDto {
         private String username;
 
         @NotEmpty
-        @Size(min = 8, max = 15)
+        @Size(min = PASSWORD_MIN_SIZE, max = PASSWORD_MAX_SIZE)
         private String password;
 
         @NotEmpty
-        @Size(min = 8, max = 15)
+        @Size(min = PASSWORD_MIN_SIZE, max = PASSWORD_MAX_SIZE)
         private String confirmPassword;
     }
 

--- a/src/main/java/miniProject/board/dto/constants/MemberConst.java
+++ b/src/main/java/miniProject/board/dto/constants/MemberConst.java
@@ -1,0 +1,10 @@
+package miniProject.board.dto.constants;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberConst {
+    public static final int PASSWORD_MIN_SIZE = 8;
+    public static final int PASSWORD_MAX_SIZE = 15;
+}

--- a/src/main/java/miniProject/board/service/member/FindAccountsService.java
+++ b/src/main/java/miniProject/board/service/member/FindAccountsService.java
@@ -10,6 +10,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 
 @Service
@@ -49,12 +50,16 @@ public class FindAccountsService {
     }
 
     // 2. 인증키 확인 서비스
-    public boolean checkAuthNum(String email, String code) {
-        if(redisUtil.getData(code) == null) {
-            return false;
-        } else {
-            return redisUtil.getData(code).equals(email);
-        }
+    public String checkAuthNum(String email, String sentCode, String authCode) {
+        String storedEmail = redisUtil.getData(authCode);
+
+        if(!Objects.equals(sentCode, authCode)) {
+            return "mismatch";
+        } if(storedEmail == null) {
+            return "expired";
+        } if(!Objects.equals(email, storedEmail)) {
+            return "mismatch";
+        } return "approve";
     }
 
     // 3. 계정 목록 확인 서비스

--- a/src/main/resources/templates/email/AuthFormForAccounts.html
+++ b/src/main/resources/templates/email/AuthFormForAccounts.html
@@ -11,10 +11,12 @@
     <h1>Enter Verification Code to Find Accounts</h1>
     <form action="/findAccounts/emailAuth" method="post">
         <input type="hidden" name="email" th:value="${email}">
+        <input type="hidden" name="sentCode" th:value="${sentCode}">
         <div class="form-group">
             <label for="authCode">Verification Code</label>
             <input type="text" class="form-control" id="authCode" name="authCode" th:value="${emailCheckDto.authCode}" required>
         </div>
+        <div class="alert alert-danger" th:if="${error}" th:text="${error}"></div>
         <button type="submit" class="btn btn-primary">Verify</button>
     </form>
 </main>

--- a/src/main/resources/templates/email/AuthFormForAccounts.html
+++ b/src/main/resources/templates/email/AuthFormForAccounts.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head th:replace="~{layouts/header/common-header :: head(~{::title})}">
-    <title>Email Form : Find Accounts</title>
+    <title>Enter Verification Code : Find Accounts</title>
 </head>
 <body class="bg-light d-flex flex-column min-vh-100">
 

--- a/src/main/resources/templates/email/AuthFormForPw.html
+++ b/src/main/resources/templates/email/AuthFormForPw.html
@@ -12,12 +12,12 @@
     <form action="/changePW/emailAuth" method="post">
         <input type="hidden" name="username" th:value="${username}">
         <input type="hidden" name="email" th:value="${email}">
-
+        <input type="hidden" name="sentCode" th:value="${sentCode}">
         <div class="form-group">
             <label for="authCode">Verification Code</label>
             <input type="text" class="form-control" id="authCode" name="authCode" th:value="${emailCheckDto.authCode}" required>
         </div>
-
+        <div class="alert alert-danger" th:if="${error}" th:text="${error}"></div>
         <button type="submit" class="btn btn-primary">Verify</button>
     </form>
 </main>

--- a/src/main/resources/templates/email/emailFormForPw.html
+++ b/src/main/resources/templates/email/emailFormForPw.html
@@ -18,6 +18,7 @@
             <label for="email">Email</label>
             <input type="email" class="form-control" id="email" name="email" th:value="${emailRequestDto.email}" required>
         </div>
+        <div class="alert alert-danger" th:if="${error}" th:text="${error}"></div>
         <button type="submit" class="btn btn-primary">Send Verification Code</button>
     </form>
 </main>

--- a/src/main/resources/templates/member/changePwForm.html
+++ b/src/main/resources/templates/member/changePwForm.html
@@ -20,6 +20,7 @@
             <label for="confirmPassword">Confirm New Password</label>
             <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" th:value="${changePWDto.confirmPassword}" required>
         </div>
+        <div class="alert alert-danger" th:if="${error}" th:text="${error}"></div>
         <button type="submit" class="btn btn-primary">Change Password</button>
     </form>
 </main>

--- a/src/main/resources/templates/member/loginForm.html
+++ b/src/main/resources/templates/member/loginForm.html
@@ -35,7 +35,10 @@
                     </div>
 
                     <div class="mb-3 text-end">
-                        <a href="#" class="text-primary">비밀번호를 잊으셨나요?</a>
+                        <a href="/findAccounts/emailCheck" class="text-primary">아이디를 잊으셨나요?</a>
+                    </div>
+                    <div class="mb-3 text-end">
+                        <a href="/changePW/emailCheck" class="text-primary">비밀번호를 잊으셨나요?</a>
                     </div>
 
                     <button class="w-100 btn btn-lg btn-primary" type="submit">로그인</button>


### PR DESCRIPTION
### 체크 리스트
<!-- 아래 항목들을 체크해 주세요. -->
- [x] PR 제목을 커밋 메시지 형식으로 작성 (예: feat: 기능 구현)
- [x] PR 요청 시 Assignee 본인 선택
- [x] PR 요청 시 Reviewers 팀원 선택

### 개요
1. 아이디 찾기/ 비밀번호 변경시 인증 코드를 오입력했을 때 코드 기한이 만기되는 문제 수정
2. 비밀번호 변경시 유저 정보 입력 단계에서 Username 계정에 등록되지 않은 이메일을 입력해도 인증 코드가 전송되던 문제 수정
3. 비밀번호 변경시 새 비밀번호 입력 단계에서 비밀번호와 비밀번호 확인의 내용이 다르더라도 비밀번호 변경이 적용되던 문제 수정

4. 아이디 찾기/ 비밀번호 변경 버튼 로그인 페이지에 추가
5. MemberDto 리팩터링
 - Email 관련 내부 클래스를 EmailDto로 이동
 - 반복 사용되는 변수를 MemberConst에 상수로 등록
 - EmailDto 생성 및 MemberDto 변경에 따라 이메일 처리 관련 컨트롤러 및 서비스 코드 리팩터링


### 작업 내용 (Optional)
<!-- 작업 내용에 대한 설명을 자세히 작성해 주세요. -->